### PR TITLE
Adjust title view position when part of the view is off screen.

### DIFF
--- a/viewtooltip/src/main/java/com/github/florent37/viewtooltip/ViewTooltip.java
+++ b/viewtooltip/src/main/java/com/github/florent37/viewtooltip/ViewTooltip.java
@@ -662,19 +662,39 @@ public class ViewTooltip {
                 layoutParams.width = screenWidth - rect.right - MARGIN_SCREEN_BORDER_TOOLTIP;
                 changed = true;
             } else if (position == Position.TOP || position == Position.BOTTOM) {
+                int adjustedLeft = rect.left;
+                int adjustedRight = rect.right;
 
                 if((rect.centerX() + getWidth() / 2f) > screenWidth){
                     float diff = (rect.centerX() + getWidth() / 2f) - screenWidth;
 
-                    rect.left -=  diff;
-                    rect.right -=  diff;
+                    adjustedLeft -=  diff;
+                    adjustedRight -=  diff;
 
                     setAlign(ALIGN.CENTER);
+                    changed = true;
+                }else if((rect.centerX() - getWidth() / 2f) < 0){
+                    float diff = -(rect.centerX() - getWidth() / 2f);
 
+                    adjustedLeft +=  diff;
+                    adjustedRight +=  diff;
+
+                    setAlign(ALIGN.CENTER);
                     changed = true;
                 }
 
+                if(adjustedLeft < 0){
+                    adjustedLeft = 0;
+                }
+
+                if(adjustedRight > screenWidth){
+                    adjustedRight = screenWidth;
+                }
+
+                rect.left = adjustedLeft;
+                rect.right = adjustedRight;
             }
+
             setLayoutParams(layoutParams);
             postInvalidate();
             return changed;


### PR DESCRIPTION
**Issue description**
It looks like changes in the commit bd02947b6d99a07c7157ed0e86d5fd4e7f03c611 has broken tooltip left position adjusting logic.

**Before the change**
![before](https://user-images.githubusercontent.com/1560140/34907436-b03c083c-f87e-11e7-9497-229fc48fcbd8.png)

**After the change**
![after](https://user-images.githubusercontent.com/1560140/34907432-ae9c3b0a-f87e-11e7-8e8c-fa42e5a40c8c.png)



