### PR TITLE
Fix bug, if rootView has globalOffset, ViewTooltip be off to the bottom.

### DIFF
--- a/viewtooltip/src/main/java/com/github/florent37/viewtooltip/ViewTooltip.java
+++ b/viewtooltip/src/main/java/com/github/florent37/viewtooltip/ViewTooltip.java
@@ -9,6 +9,7 @@ import android.graphics.Canvas;
 import android.graphics.Color;
 import android.graphics.Paint;
 import android.graphics.Path;
+import android.graphics.Point;
 import android.graphics.Rect;
 import android.graphics.RectF;
 import android.graphics.Typeface;
@@ -167,12 +168,13 @@ public class ViewTooltip {
                 @Override
                 public void run() {
                     final Rect rect = new Rect();
-                    view.getGlobalVisibleRect(rect);
+                    final Point offset = new Point();
+                    view.getGlobalVisibleRect(rect, offset);
 
                     int[] location = new int[2];
                     view.getLocationOnScreen(location);
                     rect.left = location[0];
-                    //rect.left = location[0];
+                    rect.top -= offset.y;
 
                     decorView.addView(tooltip_view, ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT);
 

--- a/viewtooltip/src/main/java/com/github/florent37/viewtooltip/ViewTooltip.java
+++ b/viewtooltip/src/main/java/com/github/florent37/viewtooltip/ViewTooltip.java
@@ -168,13 +168,15 @@ public class ViewTooltip {
                 @Override
                 public void run() {
                     final Rect rect = new Rect();
-                    final Point offset = new Point();
+                    final Point offset;
                     view.getGlobalVisibleRect(rect, offset);
 
                     int[] location = new int[2];
                     view.getLocationOnScreen(location);
                     rect.left = location[0];
-                    rect.top -= offset.y;
+                    if (offset != null) {
+                        rect.top -= offset.y;
+                    }
 
                     decorView.addView(tooltip_view, ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT);
 

--- a/viewtooltip/src/main/java/com/github/florent37/viewtooltip/ViewTooltip.java
+++ b/viewtooltip/src/main/java/com/github/florent37/viewtooltip/ViewTooltip.java
@@ -168,7 +168,7 @@ public class ViewTooltip {
                 @Override
                 public void run() {
                     final Rect rect = new Rect();
-                    final Point offset;
+                    final Point offset = new Point();
                     view.getGlobalVisibleRect(rect, offset);
 
                     int[] location = new int[2];


### PR DESCRIPTION
if rootView has globalOffset (ex. height of status bar), 
ViewToolTip be off to the bottom w/z Android 7.1.1, 8.0, 9.0.

<img width="151" alt="2018-12-27 10 30 33" src="https://user-images.githubusercontent.com/7066152/50461577-b2d32c00-09c2-11e9-9932-4394ca958952.png">
